### PR TITLE
V0.7

### DIFF
--- a/manual.py
+++ b/manual.py
@@ -87,9 +87,10 @@ def process_delegate_pmt(fee, adjust):
                     snekdb.updateDelegatePaidBalance(row[0], row[1])
                 
             else: 
-                snekdb.storePayRun(row[0], row[1], del_address(row[0]))
-                # adjust sql balances
-                snekdb.updateDelegatePaidBalance(row[0], row[1])
+                if row[1] > 0:
+                    snekdb.storePayRun(row[0], row[1], del_address(row[0]))
+                    # adjust sql balances
+                    snekdb.updateDelegatePaidBalance(row[0], row[1])
                 
 def fixed_deal():
     res = 0

--- a/tbw.py
+++ b/tbw.py
@@ -294,9 +294,10 @@ def process_delegate_pmt(fee, adjust):
                     snekdb.updateDelegatePaidBalance(row[0], row[1])
                 
             else: 
-                snekdb.storePayRun(row[0], row[1], del_address(row[0]))
-                # adjust sql balances
-                snekdb.updateDelegatePaidBalance(row[0], row[1])
+                if row[1] > 0:
+                    snekdb.storePayRun(row[0], row[1], del_address(row[0]))
+                    # adjust sql balances
+                    snekdb.updateDelegatePaidBalance(row[0], row[1])
 
 def payout():
     min = int(data['min_payment'] * atomic)


### PR DESCRIPTION
added check for 0 balances on changed/unused delegate reward address to prevent broadcasting errors